### PR TITLE
Add error dialog type and Windows and Mac icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ dialog.info('Hello there');
 
 Usage
 -------
+To show an error dialog:
+
+``` js
+dialog.err(msg, title, callback);
+```
 
 To show a generic info dialog:
 

--- a/bin/dialog.js
+++ b/bin/dialog.js
@@ -5,7 +5,7 @@ function abort(msg) {
 }
 
 if (!process.argv[3])
-  abort("Usage: show_dialog [info|warn] [message]")
+  abort("Usage: show_dialog [err|info|warn] [message]")
 
 var dialog  = require('./..'),
     type    = process.argv[2],

--- a/index.js
+++ b/index.js
@@ -57,14 +57,14 @@ var Dialog = module.exports = {
           type = 2;
           break;
         default:
-          type = "";
+          type = '';
       }
 
       str = str.replace(/"/g, "'"); // double quotes to single quotes
       cmd.push('osascript') && cmd.push('-e');
       var script = 'tell app \"System Events\" to display dialog ';
       script += '\"' + str + '\" with title \"' + title + '\" buttons \"OK\"';
-      script += " with icon " + type;
+      script += ' with icon ' + type;
       cmd.push(script);
 
     } else {

--- a/index.js
+++ b/index.js
@@ -50,11 +50,24 @@ var Dialog = module.exports = {
       cmd.push(script);
 
     } else {
+      var messageBoxType;
+
+      // Set button argument settings
+      switch (type) {
+        case 'warning':
+          messageBoxType = 16;
+          break;
+        case 'info':
+          messageBoxType = 64;
+          break;
+        default:
+          messageBoxType = 0;
+      }
 
       // msgbox.vbs script from http://stackoverflow.com/questions/774175
       cmd.push('cscript');
       cmd.push(join(__dirname, 'msgbox.vbs'));
-      cmd.push(title) && cmd.push(str);
+      cmd.push(str) && cmd.push(messageBoxType) && cmd.push(title);
 
     }
 

--- a/index.js
+++ b/index.js
@@ -8,6 +8,10 @@ var join  = require('path').join,
 
 var Dialog = module.exports = {
 
+  err: function(str, title, callback) {
+    this.show('error', str, title, callback);
+  },
+
   info: function(str, title, callback) {
     this.show('info', str, title, callback);
   },
@@ -41,33 +45,48 @@ var Dialog = module.exports = {
       if (str.length > 30) cmd.push('--width') && cmd.push('300');
 
     } else if (os_name == 'darwin') {
+      // Set dialog icon
+      switch (type) {
+        case 'error':
+          type = 0;
+          break;
+        case 'info':
+          type = 1;
+          break;
+        case 'warning':
+          type = 2;
+          break;
+        default:
+          type = "";
+      }
 
       str = str.replace(/"/g, "'"); // double quotes to single quotes
       cmd.push('osascript') && cmd.push('-e');
       var script = 'tell app \"System Events\" to display dialog ';
       script += '\"' + str + '\" with title \"' + title + '\" buttons \"OK\"';
-      script += (type == 'warning') ? " with icon 0" : "";
+      script += " with icon " + type;
       cmd.push(script);
 
     } else {
-      var messageBoxType;
-
-      // Set button argument settings
+      // Set MsgBox icon
       switch (type) {
-        case 'warning':
-          messageBoxType = 16;
+        case 'error':
+          type = 16;
           break;
         case 'info':
-          messageBoxType = 64;
+          type = 64;
+          break;
+        case 'warning':
+          type = 48;
           break;
         default:
-          messageBoxType = 0;
+          type = 0;
       }
 
       // msgbox.vbs script from http://stackoverflow.com/questions/774175
       cmd.push('cscript');
       cmd.push(join(__dirname, 'msgbox.vbs'));
-      cmd.push(str) && cmd.push(messageBoxType) && cmd.push(title);
+      cmd.push(str) && cmd.push(type) && cmd.push(title);
 
     }
 
@@ -78,7 +97,7 @@ var Dialog = module.exports = {
   run: function(cmd, cb) {
     var bin    = cmd[0],
         args   = cmd.splice(1),
-        stdout = '', 
+        stdout = '',
         stderr = '';
 
     var child = spawn(bin, args);

--- a/msgbox.vbs
+++ b/msgbox.vbs
@@ -1,4 +1,5 @@
 Set objArgs = WScript.Arguments
-messageTitle = objArgs(0)
-messageText = objArgs(1)
-MsgBox messageText, 0, messageTitle
+messageText = objArgs(0)
+messageType = objArgs(1)
+messageTitle = objArgs(2)
+MsgBox messageText, messageType, messageTitle

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Tomás Pollak <tomas@forkhq.com> (http://forkhq.com)",
   "name": "dialog",
   "description": "Show alert dialogs using Node.",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "repository": {
     "url": "https://github.com/tomas/dialog"
   },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Tomás Pollak <tomas@forkhq.com> (http://forkhq.com)",
   "name": "dialog",
   "description": "Show alert dialogs using Node.",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "repository": {
     "url": "https://github.com/tomas/dialog"
   },


### PR DESCRIPTION
This PR:
* Adds icons to Windows dialogues and add to those for Mac.
* Adds a new dialog type `error`.

I appreciate this project hasn't been active for a long time, but I can see it being potentially very handy for some NW.js work I have been doing.