### PR TITLE
Prevent console window from appearing on Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,7 +117,9 @@ var Dialog = module.exports = {
         stdout = '',
         stderr = '';
 
-    var child = spawn(bin, args);
+    var child = spawn(bin, args, {
+      detached: true
+    });
 
     child.stdout.on('data', function(data) {
       stdout += data.toString();


### PR DESCRIPTION
On Windows, a very ugly empty console window appears while the dialog box is open if you use this module from a node process that was started as a detached process:

```js
var child_process = require('child_process');
child_process.spawn('node', ['myscript.js'], {
  detached: true
});
```
```js
// myscript.js
var dialog = require('dialog');
dialog.warn(...);
```
![conhost window](https://user-images.githubusercontent.com/354349/30257026-e4463dc8-9663-11e7-8056-b105228f890c.png)


Starting cscript `detached` solves this problem.