### PR TITLE
Added custom dialog with support for text input and custom buttons/icon

### DIFF
--- a/index.js
+++ b/index.js
@@ -111,6 +111,57 @@ var Dialog = module.exports = {
 
   },
 
+  custom: function(str, title, buttons, defaultAnswer, icon, callback) {
+    
+    //defaultAnswer is used to accept text input from user. If it is empty, the dialog will not have an input text field.
+    //buttons is a string with brackets. Example: buttons = '{"No", "Maybe", "OK"}' 
+    //Maximum 3 buttons.
+    //icon is 'note' by default.
+    
+    if(process.platform != 'darwin')
+      throw new Error('This platform is not supported yet!'); //Not yet explored on non macOS devices
+
+    if (!str || str.trim() == '')
+      throw new Error('Empty or no string passed!');
+
+    if (typeof title == 'function') {
+      callback = title;
+      title = null;
+    }
+
+    if(!buttons || buttons.trim() == 0)
+      buttons='{"OK"}';
+    
+    if(!icon || icon.trim() == 0)
+      icon='note';
+
+    var cmd     = [],
+      os_name = process.platform,
+      title   = title ? title : 'Important';
+  
+    str = str.replace(/"/g, "'"); // double quotes to single quotes
+    defaultAnswer = defaultAnswer.replace(/"/g, "'"); // double quotes to single quotes
+    
+    cmd.push('osascript') && cmd.push('-e');
+    var script = 'tell app \"System Events\" '
+    
+    if(defaultAnswer)
+      script += 'to set resp '    //to get the user's text input
+      
+    script += 'to display dialog \"' + str + '\"';
+    
+    if(defaultAnswer || defaultAnswer.trim() != 0)
+      script += ' default answer \"' + defaultAnswer + '\"';
+    
+    script += ' with title \"' + title + '\" buttons ' + buttons;
+
+    script += ' with icon ' + icon;
+    console.log(script);
+    cmd.push(script);
+    console.log('\n' + cmd);
+    this.run(cmd, callback)
+  },
+
   run: function(cmd, cb) {
     var bin    = cmd[0],
         args   = cmd.splice(1),

--- a/index.js
+++ b/index.js
@@ -111,9 +111,9 @@ var Dialog = module.exports = {
 
   },
 
-  custom: function(str, title, buttons, defaultAnswer, icon, callback) {
+  custom: function(str, title, buttons, icon, callback, defaultAnswer) {
     
-    //defaultAnswer is used to accept text input from user. If it is empty, the dialog will not have an input text field.
+    //defaultAnswer is optional & is used to accept text input from user.
     //buttons is a string with brackets. Example: buttons = '{"No", "Maybe", "OK"}' 
     //Maximum 3 buttons.
     //icon is 'note' by default.
@@ -140,7 +140,6 @@ var Dialog = module.exports = {
       title   = title ? title : 'Important';
   
     str = str.replace(/"/g, "'"); // double quotes to single quotes
-    defaultAnswer = defaultAnswer.replace(/"/g, "'"); // double quotes to single quotes
     
     cmd.push('osascript') && cmd.push('-e');
     var script = 'tell app \"System Events\" '
@@ -150,8 +149,11 @@ var Dialog = module.exports = {
       
     script += 'to display dialog \"' + str + '\"';
     
-    if(defaultAnswer || defaultAnswer.trim() != 0)
+    if(defaultAnswer)
+    {
+      defaultAnswer = defaultAnswer.replace(/"/g, "'"); // double quotes to single quotes
       script += ' default answer \"' + defaultAnswer + '\"';
+    }
     
     script += ' with title \"' + title + '\" buttons ' + buttons;
 


### PR DESCRIPTION
Optional text input box can be added to dialog boxes in Darwin (MacOS) to capture additional user response.
Support to add custom icon to dialog boxes in Darwin.
Support to add custom buttons to dialog boxes in Darwin.

<img width="492" alt="screen shot 2018-02-10 at 12 54 19 am" src="https://user-images.githubusercontent.com/10463855/36045852-09d51832-0dfd-11e8-99c7-476625b78cba.png">
